### PR TITLE
Add decorator-based task and pipeline helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # MLOps-Toolbox
-Compilation of all relevant tools for better ML Operations
+
+Compilation of all relevant tools for better ML Operations.
+
+This repository provides simple decorators to mark functions as tasks or pipelines.
+
+## Decorators
+
+- `@task`: Mark a Python function as an executable task.
+- `@pipeline`: Mark a function that orchestrates multiple tasks.
+
+## Example
+
+```
+from mlops_toolbox import task, pipeline
+
+@task
+def load_data():
+    print("Loading data...")
+    return [1, 2, 3]
+
+@task
+def preprocess(data):
+    print("Preprocessing", data)
+    return [x * 2 for x in data]
+
+@pipeline
+def my_pipeline():
+    data = load_data()
+    data = preprocess(data)
+    print("Done")
+
+if __name__ == "__main__":
+    my_pipeline()
+```
+
+See `examples/simple_usage.py` for a complete runnable example.

--- a/examples/simple_usage.py
+++ b/examples/simple_usage.py
@@ -1,0 +1,31 @@
+from mlops_toolbox import task, pipeline
+
+
+@task
+def load_data():
+    print("Loading data...")
+    return [1, 2, 3]
+
+
+@task
+def preprocess(data):
+    print("Preprocessing", data)
+    return [x * 2 for x in data]
+
+
+@task
+def train_model(data):
+    print("Training model with", data)
+    return {"model": "dummy"}
+
+
+@pipeline
+def training_pipeline():
+    data = load_data()
+    processed = preprocess(data)
+    model = train_model(processed)
+    print("Pipeline result:", model)
+
+
+if __name__ == "__main__":
+    training_pipeline()

--- a/mlops_toolbox/__init__.py
+++ b/mlops_toolbox/__init__.py
@@ -1,0 +1,3 @@
+from .decorators import task, pipeline, Task, Pipeline
+
+__all__ = ["task", "pipeline", "Task", "Pipeline"]

--- a/mlops_toolbox/decorators.py
+++ b/mlops_toolbox/decorators.py
@@ -1,0 +1,48 @@
+"""Simple task and pipeline decorators."""
+
+from __future__ import annotations
+
+import functools
+from typing import Callable, Dict
+
+
+class Task:
+    """Represents a single task."""
+
+    def __init__(self, func: Callable):
+        functools.update_wrapper(self, func)
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        print(f"Running task: {self.func.__name__}")
+        return self.func(*args, **kwargs)
+
+
+class Pipeline:
+    """Represents a pipeline of tasks."""
+
+    def __init__(self, func: Callable):
+        functools.update_wrapper(self, func)
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        print(f"Running pipeline: {self.func.__name__}")
+        return self.func(*args, **kwargs)
+
+
+TASK_REGISTRY: Dict[str, Task] = {}
+PIPELINE_REGISTRY: Dict[str, Pipeline] = {}
+
+
+def task(func: Callable) -> Task:
+    """Decorator to register a function as a :class:`Task`."""
+    t = Task(func)
+    TASK_REGISTRY[func.__name__] = t
+    return t
+
+
+def pipeline(func: Callable) -> Pipeline:
+    """Decorator to register a function as a :class:`Pipeline`."""
+    p = Pipeline(func)
+    PIPELINE_REGISTRY[func.__name__] = p
+    return p


### PR DESCRIPTION
## Summary
- add a simple `mlops_toolbox` package with `@task` and `@pipeline` decorators
- provide a runnable example script demonstrating usage
- document decorators and example in README

## Testing
- `PYTHONPATH=. python examples/simple_usage.py`

------
https://chatgpt.com/codex/tasks/task_e_68786aa403d08333a44f7a9c79e66b98